### PR TITLE
Upgrades + forgeable porting flag (whitespace fixed)

### DIFF
--- a/TagTool/Commands/Bitmaps/ExtractBitmapsCommand.cs
+++ b/TagTool/Commands/Bitmaps/ExtractBitmapsCommand.cs
@@ -19,20 +19,26 @@ namespace TagTool.Commands.Bitmaps
                 "ExtractBitmaps",
                 "Extract all bitmaps to a folder",
                 
-                "ExtractBitmaps <Folder>",
+                "ExtractBitmaps <type> <directory>",
                 
-                "Extract all bitmap tags and any subimages to the given folder.\n" +
-                "If the folder does not exist, it will be created.")
+                "Extract multiple images to the provided directory.\n\n" +
+                "Available types:\n" +
+				"\t all -> Extracts every image in the current cache.")
         {
             Cache = cache;
         }
 
         public override object Execute(List<string> args)
         {
-            if (args.Count != 1)
+            if (args.Count != 2)
                 return new TagToolError(CommandError.ArgCount);
 
-            var outDir = args[0];
+			string[] types = { "all" };
+
+			if (Array.IndexOf(types, args[0]) == -1)
+				return new TagToolError(CommandError.CustomError, "Invalid extract type specified!");
+
+			var outDir = args[1];
             Directory.CreateDirectory(outDir);
 
             Console.WriteLine("Loading resource caches...");

--- a/TagTool/Commands/Bitmaps/ExtractBitmapsCommand.cs
+++ b/TagTool/Commands/Bitmaps/ExtractBitmapsCommand.cs
@@ -33,12 +33,12 @@ namespace TagTool.Commands.Bitmaps
             if (args.Count != 2)
                 return new TagToolError(CommandError.ArgCount);
 
-			string[] types = { "all" };
+            string[] types = { "all" };
 
-			if (Array.IndexOf(types, args[0]) == -1)
-				return new TagToolError(CommandError.CustomError, "Invalid extract type specified!");
+            if (Array.IndexOf(types, args[0]) == -1)
+                return new TagToolError(CommandError.CustomError, "Invalid extract type specified!");
 
-			var outDir = args[1];
+            var outDir = args[1];
             Directory.CreateDirectory(outDir);
 
             Console.WriteLine("Loading resource caches...");

--- a/TagTool/Commands/Porting/PortTagCommand.PortingOptions.cs
+++ b/TagTool/Commands/Porting/PortTagCommand.PortingOptions.cs
@@ -136,7 +136,7 @@ namespace TagTool.Commands.Porting
 			/// Add a multiplayerobject block for spawnable tag types.
 			/// </summary>
 			[PortingFlagDescription("Add a multiplayerobject block for spawnable tag types.")]
-			Forgeable = 1 << 19,
+			MPobject = 1 << 19,
 
 			// No [PortingFlagDescription] here means we'll flag names as the description.
 			Default = Recursive | Audio | Elites | ForgePalette | Squads | Scripts | MatchShaders | Rmhg | Print | Merge | GenerateShaders

--- a/TagTool/Commands/Porting/PortTagCommand.PortingOptions.cs
+++ b/TagTool/Commands/Porting/PortTagCommand.PortingOptions.cs
@@ -132,6 +132,12 @@ namespace TagTool.Commands.Porting
 			[PortingFlagDescription("Attempt to generate shaders.")]
 			GenerateShaders = 1 << 18,
 
+			/// <summary>
+			/// Add a multiplayerobject block for spawnable tag types.
+			/// </summary>
+			[PortingFlagDescription("Add a multiplayerobject block for spawnable tag types.")]
+			Forgeable = 1 << 19,
+
 			// No [PortingFlagDescription] here means we'll flag names as the description.
 			Default = Recursive | Audio | Elites | ForgePalette | Squads | Scripts | MatchShaders | Rmhg | Print | Merge | GenerateShaders
 		}

--- a/TagTool/Commands/Porting/PortTagCommand.cs
+++ b/TagTool/Commands/Porting/PortTagCommand.cs
@@ -683,25 +683,12 @@ namespace TagTool.Commands.Porting
                                 CacheContext.Serialize(cacheStream, biped.Model, hlmt);
                             }
                             break;
-                        case Crate bloc:
-                            if (FlagIsSet(PortingFlags.Forgeable) && bloc.MultiplayerObject.Count == 0)
-                                bloc.MultiplayerObject.Add(null);
-                            break;
-                        case Scenery scen:
-                            if (FlagIsSet(PortingFlags.Forgeable) && scen.MultiplayerObject.Count == 0)
-                                scen.MultiplayerObject.Add(null);
-                            break;
-                        case DeviceControl ctrl:
-                            if (FlagIsSet(PortingFlags.Forgeable) && ctrl.MultiplayerObject.Count == 0)
-                                ctrl.MultiplayerObject.Add(null);
-                            break;
-                        case DeviceMachine mach:
-                            if (FlagIsSet(PortingFlags.Forgeable) && mach.MultiplayerObject.Count == 0)
-                                mach.MultiplayerObject.Add(null);
-                            break;
                         default:
                             break;
                     };
+                    if (FlagIsSet(PortingFlags.MPobject) && blamDefinition is GameObject obj && obj.MultiplayerObject.Count == 0)
+                        obj.MultiplayerObject.Add(new GameObject.MultiplayerObjectBlock() { SpawnTime = 30, AbandonTime = 30 });
+
                     break;
 
 				case Globals matg:

--- a/TagTool/Commands/Porting/PortTagCommand.cs
+++ b/TagTool/Commands/Porting/PortTagCommand.cs
@@ -648,7 +648,7 @@ namespace TagTool.Commands.Porting
                                     weapon.TargetTracking[0].TrackingSound = ConvertTag(cacheStream, blamCacheStream, resourceStreams, ParseLegacyTag(@"sound\weapons\missile_launcher\tracking_locking\tracking_locking.sound_looping")[0]);
                                     weapon.TargetTracking[0].LockedSound = ConvertTag(cacheStream, blamCacheStream, resourceStreams, ParseLegacyTag(@"sound\weapons\missile_launcher\tracking_locked\tracking_locked.sound_looping")[0]);                                      
                                 }
-                            }                    
+                            }
                             break;
                         /*case Vehicle vehicle:
                             //fix vehicle weapon target tracking
@@ -683,7 +683,23 @@ namespace TagTool.Commands.Porting
                                 CacheContext.Serialize(cacheStream, biped.Model, hlmt);
                             }
                             break;
-                        default:
+						case Crate bloc:
+							if (FlagIsSet(PortingFlags.Forgeable) && bloc.MultiplayerObject.Count == 0)
+								bloc.MultiplayerObject.Add(null);
+							break;
+						case Scenery scen:
+							if (FlagIsSet(PortingFlags.Forgeable) && scen.MultiplayerObject.Count == 0)
+								scen.MultiplayerObject.Add(null);
+							break;
+						case DeviceControl ctrl:
+							if (FlagIsSet(PortingFlags.Forgeable) && ctrl.MultiplayerObject.Count == 0)
+								ctrl.MultiplayerObject.Add(null);
+							break;
+						case DeviceMachine mach:
+							if (FlagIsSet(PortingFlags.Forgeable) && mach.MultiplayerObject.Count == 0)
+								mach.MultiplayerObject.Add(null);
+							break;
+						default:
                             break;
                     };                                     
                     break;

--- a/TagTool/Commands/Porting/PortTagCommand.cs
+++ b/TagTool/Commands/Porting/PortTagCommand.cs
@@ -683,25 +683,25 @@ namespace TagTool.Commands.Porting
                                 CacheContext.Serialize(cacheStream, biped.Model, hlmt);
                             }
                             break;
-						case Crate bloc:
-							if (FlagIsSet(PortingFlags.Forgeable) && bloc.MultiplayerObject.Count == 0)
-								bloc.MultiplayerObject.Add(null);
-							break;
-						case Scenery scen:
-							if (FlagIsSet(PortingFlags.Forgeable) && scen.MultiplayerObject.Count == 0)
-								scen.MultiplayerObject.Add(null);
-							break;
-						case DeviceControl ctrl:
-							if (FlagIsSet(PortingFlags.Forgeable) && ctrl.MultiplayerObject.Count == 0)
-								ctrl.MultiplayerObject.Add(null);
-							break;
-						case DeviceMachine mach:
-							if (FlagIsSet(PortingFlags.Forgeable) && mach.MultiplayerObject.Count == 0)
-								mach.MultiplayerObject.Add(null);
-							break;
-						default:
+                        case Crate bloc:
+                            if (FlagIsSet(PortingFlags.Forgeable) && bloc.MultiplayerObject.Count == 0)
+                                bloc.MultiplayerObject.Add(null);
                             break;
-                    };                                     
+                        case Scenery scen:
+                            if (FlagIsSet(PortingFlags.Forgeable) && scen.MultiplayerObject.Count == 0)
+                                scen.MultiplayerObject.Add(null);
+                            break;
+                        case DeviceControl ctrl:
+                            if (FlagIsSet(PortingFlags.Forgeable) && ctrl.MultiplayerObject.Count == 0)
+                                ctrl.MultiplayerObject.Add(null);
+                            break;
+                        case DeviceMachine mach:
+                            if (FlagIsSet(PortingFlags.Forgeable) && mach.MultiplayerObject.Count == 0)
+                                mach.MultiplayerObject.Add(null);
+                            break;
+                        default:
+                            break;
+                    };
                     break;
 
 				case Globals matg:

--- a/TagTool/Commands/Strings/StringIdCommand.cs
+++ b/TagTool/Commands/Strings/StringIdCommand.cs
@@ -61,7 +61,7 @@ namespace TagTool.Commands.Strings
 
             if (Cache.StringTable.Contains(str))
             {
-                Console.WriteLine("String already exists");
+                Console.WriteLine("ERROR: That string already exists!");
                 return true;
             }
 
@@ -87,7 +87,7 @@ namespace TagTool.Commands.Strings
             if (str != null)
                 Console.WriteLine(str);
             else
-                Console.WriteLine("Unable to find a string with ID 0x{0:X}.", stringId);
+                Console.WriteLine("ERROR: Unable to find a string with ID 0x{0:X}.", stringId);
 
             return true;
         }
@@ -160,7 +160,7 @@ namespace TagTool.Commands.Strings
 
             if (strings.Count == 0)
             {
-                Console.WriteLine("No strings found.");
+                Console.WriteLine("ERROR: No strings found!");
                 return true;
             }
 

--- a/TagTool/Commands/Tags/DuplicateTagCommand.cs
+++ b/TagTool/Commands/Tags/DuplicateTagCommand.cs
@@ -28,9 +28,11 @@ namespace TagTool.Commands.Tags
             if (!Cache.TagCache.TryGetCachedTag(args[0], out var originalTag))
                 return new TagToolError(CommandError.TagInvalid);
 
-            var newTag = Cache.TagCache.AllocateTag(originalTag.Group);
+            var name = "";
             if (args.Count == 2)
-                newTag = Cache.TagCache.AllocateTag(originalTag.Group, args[1]);
+                name = args[1];
+
+            var newTag = Cache.TagCache.AllocateTag(originalTag.Group, name);
 
             using (var stream = Cache.OpenCacheReadWrite())
             {

--- a/TagTool/Commands/Tags/DuplicateTagCommand.cs
+++ b/TagTool/Commands/Tags/DuplicateTagCommand.cs
@@ -29,23 +29,23 @@ namespace TagTool.Commands.Tags
                 return new TagToolError(CommandError.TagInvalid);
 
             var newTag = Cache.TagCache.AllocateTag(originalTag.Group);
-			if (args.Count == 2)
-				newTag = Cache.TagCache.AllocateTag(originalTag.Group, args[1]);
+            if (args.Count == 2)
+                newTag = Cache.TagCache.AllocateTag(originalTag.Group, args[1]);
 
-			using (var stream = Cache.OpenCacheReadWrite())
+            using (var stream = Cache.OpenCacheReadWrite())
             {
                 var originalDefinition = Cache.Deserialize(stream, originalTag);
                 Cache.Serialize(stream, newTag, originalDefinition);
 
-				//Cache.SaveTagNames();
-			}
+                //Cache.SaveTagNames();
+            }
 
-			if (args.Count == 2)
-				Console.WriteLine($"[Index: 0x{newTag.Index:X4}] {args[1]}.{newTag.Group}");
-			else
-				Console.Write($"Tag duplicated to 0x{newTag.Index.ToString("X")}\n");
+            if (args.Count == 2)
+                Console.WriteLine($"[Index: 0x{newTag.Index:X4}] {args[1]}.{newTag.Group}");
+            else
+                Console.Write($"Tag duplicated to 0x{newTag.Index.ToString("X")}\n");
 
-			return true;
+            return true;
         }
     }
 }

--- a/TagTool/Commands/Tags/DuplicateTagCommand.cs
+++ b/TagTool/Commands/Tags/DuplicateTagCommand.cs
@@ -23,21 +23,29 @@ namespace TagTool.Commands.Tags
 
         public override object Execute(List<string> args)
         {
-            if (args.Count < 1)
+            if (args.Count < 1 || args.Count > 2)
                 return new TagToolError(CommandError.ArgCount);
             if (!Cache.TagCache.TryGetCachedTag(args[0], out var originalTag))
                 return new TagToolError(CommandError.TagInvalid);
 
             var newTag = Cache.TagCache.AllocateTag(originalTag.Group);
+			if (args.Count == 2)
+				newTag = Cache.TagCache.AllocateTag(originalTag.Group, args[1]);
 
-            using (var stream = Cache.OpenCacheReadWrite())
+			using (var stream = Cache.OpenCacheReadWrite())
             {
                 var originalDefinition = Cache.Deserialize(stream, originalTag);
                 Cache.Serialize(stream, newTag, originalDefinition);
-            }
 
-            Console.Write($"Tag duplicated to 0x{newTag.Index.ToString("X")}\n");
-            return true;
+				//Cache.SaveTagNames();
+			}
+
+			if (args.Count == 2)
+				Console.WriteLine($"[Index: 0x{newTag.Index:X4}] {args[1]}.{newTag.Group}");
+			else
+				Console.Write($"Tag duplicated to 0x{newTag.Index.ToString("X")}\n");
+
+			return true;
         }
     }
 }


### PR DESCRIPTION
- Optional name assignment when duplicating tag
- Add "ERROR" text to StringID error output
- "Forgeable" porting flag adds a multiplayerobject block to relevant obje when not present
- Require an additional argument to extract all bitmaps in a cache to prevent accidental use