### PR TITLE
11.1.604673 cert_ms29 Live support

### DIFF
--- a/TagTool/Cache/CacheFile/CacheFileHeader.cs
+++ b/TagTool/Cache/CacheFile/CacheFileHeader.cs
@@ -77,6 +77,7 @@ namespace TagTool.Cache
                 case CacheVersion.HaloOnline532911:
                 case CacheVersion.HaloOnline554482:
                 case CacheVersion.HaloOnline571627:
+                case CacheVersion.HaloOnline604673:
                 case CacheVersion.HaloOnline700123:
                     return deserializer.Deserialize<CacheFileHeaderGenHaloOnline>(dataContext);
                 case CacheVersion.Halo4:

--- a/TagTool/Cache/CacheVersionDetection.cs
+++ b/TagTool/Cache/CacheVersionDetection.cs
@@ -151,6 +151,10 @@ namespace TagTool.Cache
                     version = CacheVersion.HaloOnline571627;
                     cachePlatform = CachePlatform.Original;
                     break;
+                case "11.1.601838 Live":
+                    version = CacheVersion.HaloOnline604673;
+                    cachePlatform = CachePlatform.Original;
+                    break;
                 case "12.1.700123 cert_ms30_oct19":
                     version = CacheVersion.HaloOnline700123;
                     cachePlatform = CachePlatform.Original;
@@ -258,6 +262,8 @@ namespace TagTool.Cache
                         return "11.1.554482 Live";
                     case CacheVersion.HaloOnline571627:
                         return "11.1.571627 Live";
+                    case CacheVersion.HaloOnline604673:
+                        return "11.1.604673 cert_ms29 Live";
                     case CacheVersion.HaloOnline700123:
                         return "12.1.700123 cert_ms30_oct19";
                     case CacheVersion.HaloReach:
@@ -314,8 +320,9 @@ namespace TagTool.Cache
 				case CacheVersion.HaloOnline530605:
 				case CacheVersion.HaloOnline532911:
 				case CacheVersion.HaloOnline554482:
-				case CacheVersion.HaloOnline571627:
-				case CacheVersion.HaloOnline700123:
+                case CacheVersion.HaloOnline571627:
+                case CacheVersion.HaloOnline604673:
+                case CacheVersion.HaloOnline700123:
                     return true;
 
 				default:
@@ -514,6 +521,7 @@ namespace TagTool.Cache
                 case CacheVersion.HaloOnline532911:
                 case CacheVersion.HaloOnline554482:
                 case CacheVersion.HaloOnline571627:
+                case CacheVersion.HaloOnline604673:
                 case CacheVersion.HaloOnline700123:
                     return CacheGeneration.HaloOnline;
 
@@ -570,6 +578,7 @@ namespace TagTool.Cache
                 case CacheVersion.HaloOnline532911:
                 case CacheVersion.HaloOnline554482:
                 case CacheVersion.HaloOnline571627:
+                case CacheVersion.HaloOnline604673:
                 case CacheVersion.HaloOnline700123:
                     return GameTitle.HaloOnline;
                 case CacheVersion.HaloReach:
@@ -603,6 +612,7 @@ namespace TagTool.Cache
             [130869644198634503] = CacheVersion.HaloOnline532911,
             [130879952719550501] = CacheVersion.HaloOnline554482,
             [130881889330693956] = CacheVersion.HaloOnline571627,
+            [130893802351772672] = CacheVersion.HaloOnline604673,
             [130930071628935939] = CacheVersion.HaloOnline700123
         };
 
@@ -636,6 +646,7 @@ namespace TagTool.Cache
             130869644198634503, // V11_1_532911_Live
             130879952719550501, // V11_1_554482_Live
             130881889330693956, // HaloOnline571627
+            130893802351772672, // HaloOnline604673
             130930071628935939, // HaloOnline700123
             -1, // HaloReach
             -1  // Halo 4
@@ -669,6 +680,7 @@ namespace TagTool.Cache
         HaloOnline532911,
         HaloOnline554482,
         HaloOnline571627,
+        HaloOnline604673,
         HaloOnline700123,
         HaloReach,
         HaloReach11883,

--- a/TagTool/Cache/GameCache.cs
+++ b/TagTool/Cache/GameCache.cs
@@ -94,6 +94,7 @@ namespace TagTool.Cache
                 case CacheVersion.HaloOnline532911:
                 case CacheVersion.HaloOnline554482:
                 case CacheVersion.HaloOnline571627:
+                case CacheVersion.HaloOnline604673:
                 case CacheVersion.HaloOnline700123:
                     {
                         var directory = file.Directory.FullName;

--- a/TagTool/Cache/Gen3/TagDefinitionsGen3.cs
+++ b/TagTool/Cache/Gen3/TagDefinitionsGen3.cs
@@ -72,6 +72,7 @@ namespace TagTool.Cache.Gen3
             { new TagGroupGen3("gpdt", "game_progression"), typeof(GameProgression) },
             { new TagGroupGen3("gpix", "global_cache_file_pixel_shaders"), typeof(GlobalCacheFilePixelShaders) },
             { new TagGroupGen3("grup", "gui_group_widget_definition"), typeof(GuiGroupWidgetDefinition) },
+            { new TagGroupGen3("hf2p", "hf2p_globals"), typeof(Hf2pGlobals) },
             { new TagGroupGen3("hlmt", "model"), typeof(Model) },
             { new TagGroupGen3("hlsl", "hlsl_include"), typeof(HlslInclude) },
             { new TagGroupGen3("inpg", "input_globals"), typeof(InputGlobals) },

--- a/TagTool/Geometry/RenderGeometry/RenderMaterial.cs
+++ b/TagTool/Geometry/RenderGeometry/RenderMaterial.cs
@@ -10,7 +10,7 @@ namespace TagTool.Geometry
     /// A material describing how a mesh part should be rendered.
     /// </summary>
     [TagStructure(Size = 0x20, MaxVersion = CacheVersion.Halo2Vista)]
-    [TagStructure(Size = 0x24, MaxVersion = CacheVersion.HaloOnline571627)]
+    [TagStructure(Size = 0x24, MaxVersion = CacheVersion.HaloOnline604673)]
     [TagStructure(Size = 0x30, MaxVersion = CacheVersion.HaloOnline700123)]
     [TagStructure(Size = 0x2C, MinVersion = CacheVersion.HaloReach)]
     public class RenderMaterial : TagStructure

--- a/TagTool/Geometry/RenderGeometry/VertexBuffer/VertexStreamFactory.cs
+++ b/TagTool/Geometry/RenderGeometry/VertexBuffer/VertexStreamFactory.cs
@@ -42,6 +42,7 @@ namespace TagTool.Geometry
                     case CacheVersion.HaloOnline532911:
                     case CacheVersion.HaloOnline554482:
                     case CacheVersion.HaloOnline571627:
+                    case CacheVersion.HaloOnline604673:
                     case CacheVersion.HaloOnline700123:
                         return new VertexStreamMS25(stream);
 

--- a/TagTool/TagTool.csproj
+++ b/TagTool/TagTool.csproj
@@ -1300,6 +1300,7 @@
     <Compile Include="Tags\Definitions\Rumble.cs" />
     <Compile Include="Tags\Definitions\ShaderGlass.cs" />
     <Compile Include="Tags\Definitions\TestDefinition.cs" />
+    <Compile Include="Tags\Definitions\Hf2pGlobals.cs" />
     <Compile Include="Tags\Resources\BitmapTextureInterleavedInteropResource.cs" />
     <Compile Include="Tags\Resources\BitmapTextureInteropResource.cs" />
     <Compile Include="Tags\Resources\Gen4\BinkResource.cs" />

--- a/TagTool/Tags/Definitions/Bink.cs
+++ b/TagTool/Tags/Definitions/Bink.cs
@@ -4,7 +4,7 @@ using static TagTool.Tags.TagFieldFlags;
 
 namespace TagTool.Tags.Definitions
 {
-    [TagStructure(Name = "bink", Tag = "bink", Size = 0x18, MaxVersion = CacheVersion.HaloOnline571627)]
+    [TagStructure(Name = "bink", Tag = "bink", Size = 0x18, MaxVersion = CacheVersion.HaloOnline604673)]
     [TagStructure(Name = "bink", Tag = "bink", Size = 0x14, MinVersion = CacheVersion.HaloOnline700123)]
     public class Bink : TagStructure
 	{

--- a/TagTool/Tags/Definitions/ChudDefinition.cs
+++ b/TagTool/Tags/Definitions/ChudDefinition.cs
@@ -82,7 +82,7 @@ namespace TagTool.Tags.Definitions
 
             [TagStructure(Size = 0x28, MaxVersion = CacheVersion.Halo3Retail)]
             [TagStructure(Size = 0x38, MaxVersion = CacheVersion.Halo3ODST)]
-            [TagStructure(Size = 0x44, MaxVersion = CacheVersion.HaloOnline571627)]
+            [TagStructure(Size = 0x44, MaxVersion = CacheVersion.HaloOnline604673)]
             [TagStructure(Size = 0x48, MinVersion = CacheVersion.HaloOnline700123)]
             public class StateDatum : TagStructure
             {

--- a/TagTool/Tags/Definitions/GameObject.cs
+++ b/TagTool/Tags/Definitions/GameObject.cs
@@ -49,6 +49,7 @@ namespace TagTool.Tags.Definitions
 
         public StringId DefaultModelVariant;
         public CachedTag Model;
+        [TagField(MaxVersion = CacheVersion.HaloOnline416097)]
         public CachedTag CrateObject;
         public CachedTag CollisionDamage;
 

--- a/TagTool/Tags/Definitions/Globals.cs
+++ b/TagTool/Tags/Definitions/Globals.cs
@@ -11,7 +11,7 @@ namespace TagTool.Tags.Definitions
     [TagStructure(Name = "globals", Tag = "matg", Size = 0x5F8, MaxVersion = CacheVersion.Halo3Retail, Platform = CachePlatform.MCC)]
     [TagStructure(Name = "globals", Tag = "matg", Size = 0x5AC, MaxVersion = CacheVersion.Halo3ODST)]
     [TagStructure(Name = "globals", Tag = "matg", Size = 0x608, MaxVersion = CacheVersion.HaloOnline449175)]
-    [TagStructure(Name = "globals", Tag = "matg", Size = 0x618, MinVersion = CacheVersion.HaloOnline498295, MaxVersion = CacheVersion.HaloOnline571627)]
+    [TagStructure(Name = "globals", Tag = "matg", Size = 0x618, MinVersion = CacheVersion.HaloOnline498295, MaxVersion = CacheVersion.HaloOnline604673)]
     [TagStructure(Name = "globals", Tag = "matg", Size = 0x614, MinVersion = CacheVersion.HaloOnline700123, MaxVersion = CacheVersion.HaloOnline700123)]
     [TagStructure(Name = "globals", Tag = "matg", Size = 0x714, MinVersion = CacheVersion.HaloReach, MaxVersion = CacheVersion.HaloReach11883)]
     [TagStructure(Name = "globals", Tag = "matg", Size = 0x7A8, MinVersion = CacheVersion.HaloReach, Platform = CachePlatform.MCC)]

--- a/TagTool/Tags/Definitions/Hf2pGlobals.cs
+++ b/TagTool/Tags/Definitions/Hf2pGlobals.cs
@@ -1,0 +1,33 @@
+using TagTool.Cache;
+using TagTool.Common;
+using System.Collections.Generic;
+
+namespace TagTool.Tags.Definitions
+{
+    [TagStructure(Name = "hf2p_globals", Tag = "hf2p", Size = 0x10, MinVersion = CacheVersion.HaloOnline498295)]
+    public class Hf2pGlobals : TagStructure
+	{
+        public List<Armor> RaceArmors;
+
+        [TagStructure(Size = 0xC, MinVersion = CacheVersion.HaloOnline498295)]
+        public class Armor : TagStructure
+		{
+            public List<Gender> Genders;
+
+            [TagStructure(Size = 0xC, MinVersion = CacheVersion.HaloOnline498295)]
+            public class Gender : TagStructure
+			{
+                public List<ArmorObject> ArmorObjects;
+
+                [TagStructure(Size = 0x34, MinVersion = CacheVersion.HaloOnline498295)]
+                public class ArmorObject : TagStructure
+                {
+                    [TagField(Length = 32)]
+                    public string Name;
+                    public CachedTag Armor;
+                    public StringId Variant;
+                }
+            }
+        }
+    }
+}

--- a/TagTool/Tags/Definitions/MultiplayerGlobals.cs
+++ b/TagTool/Tags/Definitions/MultiplayerGlobals.cs
@@ -19,8 +19,11 @@ namespace TagTool.Tags.Definitions
 		{
             public CachedTag RandomPlayerNameStrings;
             public CachedTag TeamNameStrings;
+
+            [TagField(MaxVersion = CacheVersion.HaloOnlineED)]
             public List<MultiplayerColor> TeamColors;
 
+            [TagField(MaxVersion = CacheVersion.HaloOnlineED)]
             public List<CustomizedModelCharacter> CustomizableCharacters;
 
             [TagField(MinVersion = CacheVersion.HaloOnlineED)]

--- a/TagTool/Tags/Definitions/ScenarioStructureBsp.cs
+++ b/TagTool/Tags/Definitions/ScenarioStructureBsp.cs
@@ -15,7 +15,7 @@ namespace TagTool.Tags.Definitions
     [TagStructure(Name = "scenario_structure_bsp", Tag = "sbsp", Size = 0x388, MaxVersion = CacheVersion.Halo3Retail)]
     [TagStructure(Name = "scenario_structure_bsp", Tag = "sbsp", Size = 0x394, MaxVersion = CacheVersion.Halo3ODST)]
     [TagStructure(Name = "scenario_structure_bsp", Tag = "sbsp", Size = 0x3AC, MinVersion = CacheVersion.HaloOnlineED, MaxVersion = CacheVersion.HaloOnline106708)]
-    [TagStructure(Name = "scenario_structure_bsp", Tag = "sbsp", Size = 0x3B8, MinVersion = CacheVersion.HaloOnline700123, MaxVersion = CacheVersion.HaloOnline700123)]
+    [TagStructure(Name = "scenario_structure_bsp", Tag = "sbsp", Size = 0x3B8, MinVersion = CacheVersion.HaloOnline604673, MaxVersion = CacheVersion.HaloOnline700123)]
     [TagStructure(Name = "scenario_structure_bsp", Tag = "sbsp", Size = 0x51C, MinVersion = CacheVersion.HaloReach)]
     public class ScenarioStructureBsp : TagStructure
     {

--- a/TagTool/Tags/Definitions/TextureRenderList.cs
+++ b/TagTool/Tags/Definitions/TextureRenderList.cs
@@ -5,7 +5,9 @@ using System.Collections.Generic;
 namespace TagTool.Tags.Definitions
 {
     // TODO: Update this for cert_ms30_oct19
-    [TagStructure(Name = "texture_render_list", Tag = "trdf", Size = 0x48, MinVersion = CacheVersion.HaloOnlineED, MaxVersion = CacheVersion.HaloOnline700123)]
+    [TagStructure(Name = "texture_render_list", Tag = "trdf", Size = 0x48, MinVersion = CacheVersion.HaloOnlineED, MaxVersion = CacheVersion.HaloOnline235640)]
+    [TagStructure(Name = "texture_render_list", Tag = "trdf", Size = 0x3C, MinVersion = CacheVersion.HaloOnline498295, MaxVersion = CacheVersion.HaloOnline604673)]
+    //[TagStructure(Name = "texture_render_list", Tag = "trdf", Size = 0x60, MinVersion = CacheVersion.HaloOnline700123, MaxVersion = CacheVersion.HaloOnline700123)]
     public class TextureRenderList : TagStructure
 	{
         public List<Bitmap> Bitmaps;
@@ -13,8 +15,11 @@ namespace TagTool.Tags.Definitions
         public List<Bink> Binks;
         public List<Mannequin> Mannequins;
         public List<Weapon> Weapons;
+        [TagField(MaxVersion = CacheVersion.HaloOnline235640)]
         public uint Unknown;
+        [TagField(MaxVersion = CacheVersion.HaloOnline235640)]
         public uint Unknown2;
+        [TagField(MaxVersion = CacheVersion.HaloOnline235640)]
         public uint Unknown3;
 
         [TagStructure(Size = 0x110)]
@@ -27,11 +32,11 @@ namespace TagTool.Tags.Definitions
             public int Height;
         }
 
-        [TagStructure(Size = 0x1C, MaxVersion = CacheVersion.HaloOnline571627)]
+        [TagStructure(Size = 0x1C, MaxVersion = CacheVersion.HaloOnline604673)]
         [TagStructure(Size = 0x28, MinVersion = CacheVersion.HaloOnline700123)]
         public class Light : TagStructure
 		{
-            [TagField(MaxVersion = CacheVersion.HaloOnline571627)]
+            [TagField(MaxVersion = CacheVersion.HaloOnline604673)]
             public List<UnknownBlock> Unknown;
 
             [TagField(MinVersion = CacheVersion.HaloOnline700123)]
@@ -66,13 +71,20 @@ namespace TagTool.Tags.Definitions
             public CachedTag Bink2;
         }
 
-        [TagStructure(Size = 0x4C)]
+        [TagStructure(Size = 0x4C, MinVersion = CacheVersion.HaloOnlineED, MaxVersion = CacheVersion.HaloOnline235640)]
+        [TagStructure(Size = 0x5C, MinVersion = CacheVersion.HaloOnline498295, MaxVersion = CacheVersion.HaloOnline604673)]
         public class Mannequin : TagStructure
 		{
             public int Unknown;
-            public CachedTag Biped;
+            [TagField(MinVersion = CacheVersion.HaloOnline498295)]
             public int Unknown2;
+            public CachedTag Biped;
+            [TagField(MinVersion = CacheVersion.HaloOnline498295)]
+            public CachedTag Animation;
+
+            [TagField(MaxVersion = CacheVersion.HaloOnline235640)]
             public float Unknown3;
+
             public float Unknown4;
             public float Unknown5;
             public float Unknown6;
@@ -85,14 +97,20 @@ namespace TagTool.Tags.Definitions
             public float Unknown13;
             public float Unknown14;
             public float Unknown15;
+            public float Unknown16;
         }
 
-        [TagStructure(Size = 0x64)]
+        [TagStructure(Size = 0x64, MinVersion = CacheVersion.HaloOnlineED, MaxVersion = CacheVersion.HaloOnline235640)]
+        [TagStructure(Size = 0x94, MinVersion = CacheVersion.HaloOnline498295, MaxVersion = CacheVersion.HaloOnline604673)]
         public class Weapon : TagStructure
 		{
-            [TagField(Length = 32)] public string Name;
+            [TagField(Length = 32)]
+            public string Name;
+            [TagField(Length = 32, MinVersion = CacheVersion.HaloOnline498295)]
+            public string Name2;
+            [TagField(MaxVersion = CacheVersion.HaloOnline235640)]
             public CachedTag Weapon2;
-            public float Unknown;
+            public float Unknown1;
             public float Unknown2;
             public float Unknown3;
             public float Unknown4;
@@ -105,6 +123,23 @@ namespace TagTool.Tags.Definitions
             public float Unknown11;
             public float Unknown12;
             public float Unknown13;
+
+            [TagField(MinVersion = CacheVersion.HaloOnline498295)]
+            public int Unknown14;
+            [TagField(MinVersion = CacheVersion.HaloOnline498295)]
+            public Angle UnknownAngle1;
+            [TagField(MinVersion = CacheVersion.HaloOnline498295)]
+            public Angle UnknownAngle2;
+            [TagField(MinVersion = CacheVersion.HaloOnline498295)]
+            public Angle UnknownAngle3;
+            [TagField(MinVersion = CacheVersion.HaloOnline498295)]
+            public float Unknown15;
+            [TagField(MinVersion = CacheVersion.HaloOnline498295)]
+            public float Unknown16;
+            [TagField(MinVersion = CacheVersion.HaloOnline498295)]
+            public float Unknown17;
+            [TagField(MinVersion = CacheVersion.HaloOnline498295)]
+            public float Unknown18;
         }
     }
 }


### PR DESCRIPTION
Adds support for the latest public ms29 build release

Known issues:
- The sweg & swel tag groups lack definitions
- The zone, sbsp, smdt and chdt groups have definition issues with ms29, with the first two unable load