### PR TITLE
Rigid Body Ignores Gravity Bit Flag

### DIFF
--- a/TagTool/Tags/Definitions/PhysicsModel.cs
+++ b/TagTool/Tags/Definitions/PhysicsModel.cs
@@ -610,7 +610,7 @@ namespace TagTool.Tags.Definitions
                 HasNoPhantomPowerVersion = 1 << 5, //don't check this flag without talking to eamon
                 InfiniteInertiaTensor = 1 << 6, //rigid body will never have angular velocity
                 bit7 = 1 << 7,
-                bit8 = 1 << 8,
+                IgnoresGravity = 1 << 8,
                 bit9 = 1 << 9,
                 bit10 = 1 << 10,
                 bit11 = 1 << 11,


### PR DESCRIPTION
Lines up with ODST Editing Kit, so bit7 is most likely "can use mopps" as well.
Flag Behavior Proof:

https://user-images.githubusercontent.com/126363312/221386093-15e9a829-1c12-4980-8665-b00d19e20592.mp4

ODST EK Rigid Body Bit Flags:
![ODST](https://user-images.githubusercontent.com/126363312/221386124-5d720d69-1a68-4567-96ce-f6c36fa9453c.PNG)
